### PR TITLE
Añadir un método para que cualquiera utilice el bot rápidamente.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ Si quieres cambiar las contestaciones, no tienes más que editar el
 fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
 
-ola

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Si tienes instalado Go, para que esto funcione dale a
 (tendrás que definir antes GOPATH y GOBIN para que instale
 correctamente la librería).
 
+
 Consíguete despues
 [tu propio API key para Telegram creando tu robot](http://bytelix.com/guias/crear-propio-bot-telegram/). Asígnaselo
 a una variable de entorno con
@@ -29,3 +30,9 @@ Si quieres cambiar las contestaciones, no tienes más que editar el
 fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
 
+
+## Para probar como funciona 
+
+Existe un bot que se ejecuta en un servidor de Cloud9 y utiliza el código de este repositorio, actualizándose automáticamente. 
+Para ver qué es lo que hace basta con abrir una conversación de telegram con él a través de este enlace: 
+[https://telegram.me/CuantoQuedaBot](https://telegram.me/CuantoQuedaBot)

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ encendido todo el tiempo (o casi) como Nitrous o Cloud9.
 Si quieres cambiar las contestaciones, no tienes más que editar el
 fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
+
+aa

--- a/README.md
+++ b/README.md
@@ -28,5 +28,3 @@ encendido todo el tiempo (o casi) como Nitrous o Cloud9.
 Si quieres cambiar las contestaciones, no tienes más que editar el
 fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
-
-aa

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
 
 
-## Para probar como funciona 
+## Utilizar el bot
 
 Existe un bot que se ejecuta en un servidor de Cloud9 y utiliza el código de este repositorio, actualizándose automáticamente. 
-Para ver qué es lo que hace basta con abrir una conversación de telegram con él a través de este enlace: 
+Para utilizar el bot tal y como está programado en este repositorio basta con iniciar una conversación en telegram con él a través de este enlace:
+
 [https://telegram.me/CuantoQuedaBot](https://telegram.me/CuantoQuedaBot)

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ encendido todo el tiempo (o casi) como Nitrous o Cloud9.
 Si quieres cambiar las contestaciones, no tienes más que editar el
 fichero [`hitos.json`](hitos.json) y poner los títulos y URLs que
 quieras. 
+
+ola

--- a/hitos.json
+++ b/hitos.json
@@ -9,6 +9,6 @@
           "fecha": "06/10/2016"},
 	{ "file": "2.CI",
 	  "title": "Test e integración continua",
-          "fecha": "27/10/2016"}
+          "fecha": "28/10/2016"}
     ]
 }

--- a/hitos.json
+++ b/hitos.json
@@ -9,6 +9,6 @@
           "fecha": "06/10/2016"},
 	{ "file": "2.CI",
 	  "title": "Test e integración continua",
-          "fecha": "28/10/2016"}
+          "fecha": "27/10/2016"}
     ]
 }


### PR DESCRIPTION
No sé si era esto a lo que te referías exactamente, pero aprovechando que había creado un "workspace" en cloud9 para probar el programa, he pensado que estaría bien tener un Boot funcionando todo el tiempo para que quien quiera utilizar el bot "por defecto", quizá simplemente para ver como funciona, no tenga que ejecutarlo en su pc o en un servidor y pueda usarlo directamente en telegram, simplemente abriendo una conversación con el bot en cuestión, utilizando el enlace: https://telegram.me/CuantoQuedaBot 

Este pull request es solo un cambio al README.md explicando esto. 

Un saludo! espero que sirva de algo :) 
